### PR TITLE
README.md

### DIFF
--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -21,3 +21,4 @@ jobs:
       - uses: JS-DevTools/npm-publish@v2
         with:
           token: ${{ secrets.NPM_TOKEN }}
+          access: public

--- a/.github/workflows/publish-npm.yaml
+++ b/.github/workflows/publish-npm.yaml
@@ -1,0 +1,23 @@
+on:
+  push:
+    tags:        
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write # allow GITHUB_TOKEN to publish packages
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - run: npm ci
+      - run: npm run build
+      - run: npm test
+      - uses: JS-DevTools/npm-publish@v2
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,8 @@
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    tags:        
+      - '*'
+  workflow_dispatch:
 
 jobs:
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .env
 out
+dist

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+tsconfig.json
+./src

--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
 # Aori TypeScript SDK
+
+This repository contains all the code required to locally install and run the Aori SDK. 
+This repo was designed such that integrations for our partners can be as smooth and seamless as possible, providing all the necessary abstractions to allow anyone to easily start building on top of the Aori Protocol.
+If you have any further questions, refer to [the technical documentation](https://www.aori.io/developers).
+Alternatively, please reach out to us [on Discord](https://discord.gg/K37wkh2ZfR) or [on Twitter](https://twitter.com/aori_io).
+
+Contained within this SDK are the following utilities:
+- Types: All custom types used within the Protocol
+- Provider: AoriProvider class allows for connection to the protocol and includes class extensions OrderbookListener and LimitOrderManager
+- Dynamic Order Hashing: Utilizes EIP-712 standard for generating typed data hashes for orders + OrderHasher class for deriving unique order hashes
+
+This SDK is released under the [MIT License](LICENSE).
+
+**Installation**
+
+To install the SDK, run the following command:
+
+```bash
+npm install @aori-io/sdk
+```
+
+Or using Yarn:
+
+```bash
+yarn add @aori-io/sdk
+```
+
+**Initialization**
+
+After installation, use the following import command interact with the SDK:
+
+```typescript
+import * as AoriSDK from '@aori-io/sdk';
+```
+Then access specific functions like so:
+```typescript
+const formattedLimitOrder = AoriSDK.formatIntoLimitOrder();
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,13 @@
 {
-  "name": "example-market-makers",
+  "name": "@aori-io/sdk",
+  "version": "0.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "@aori-io/sdk",
+      "version": "0.0.9",
+      "license": "MIT",
       "dependencies": {
         "@opensea/seaport-js": "^2.0.7",
         "dotenv": "^16.3.1",
@@ -15,10 +19,8 @@
         "@types/ws": "^8.5.5",
         "ts-node": "^10.9.1",
         "typechain": "^8.3.1",
-        "typed-emitter": "^2.1.0",
         "typescript": "^5.2.2"
-      },
-      "version": "0.0.9"
+      }
     },
     "node_modules/@0xsequence/abi": {
       "version": "0.43.34",
@@ -1891,16 +1893,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "dev": true,
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -2092,15 +2084,6 @@
         "typescript": ">=4.3.0"
       }
     },
-    "node_modules/typed-emitter": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
-      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
-      "dev": true,
-      "optionalDependencies": {
-        "rxjs": "*"
-      }
-    },
     "node_modules/typescript": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
@@ -2223,6 +2206,5 @@
         "node": ">=6"
       }
     }
-  },
-  "version": "0.0.9"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typed-emitter": "^2.1.0",
         "typescript": "^5.2.2"
       },
-      "version": "0.0.7"
+      "version": "0.0.8"
     },
     "node_modules/@0xsequence/abi": {
       "version": "0.43.34",
@@ -2224,5 +2224,5 @@
       }
     }
   },
-  "version": "0.0.7"
+  "version": "0.0.8"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typed-emitter": "^2.1.0",
         "typescript": "^5.2.2"
       },
-      "version": "0.0.3"
+      "version": "0.0.4"
     },
     "node_modules/@0xsequence/abi": {
       "version": "0.43.34",
@@ -2224,5 +2224,5 @@
       }
     }
   },
-  "version": "0.0.3"
+  "version": "0.0.4"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typed-emitter": "^2.1.0",
         "typescript": "^5.2.2"
       },
-      "version": "0.0.2"
+      "version": "0.0.3"
     },
     "node_modules/@0xsequence/abi": {
       "version": "0.43.34",
@@ -2224,5 +2224,5 @@
       }
     }
   },
-  "version": "0.0.2"
+  "version": "0.0.3"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aori-io/sdk",
-      "version": "0.0.9",
+      "version": "0.0.10",
       "license": "MIT",
       "dependencies": {
         "@opensea/seaport-js": "^2.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aori-io/sdk",
-      "version": "0.0.10",
+      "version": "0.0.11",
       "license": "MIT",
       "dependencies": {
         "@opensea/seaport-js": "^2.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typed-emitter": "^2.1.0",
         "typescript": "^5.2.2"
       },
-      "version": "0.0.4"
+      "version": "0.0.5"
     },
     "node_modules/@0xsequence/abi": {
       "version": "0.43.34",
@@ -2224,5 +2224,5 @@
       }
     }
   },
-  "version": "0.0.4"
+  "version": "0.0.5"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typed-emitter": "^2.1.0",
         "typescript": "^5.2.2"
       },
-      "version": "0.0.8"
+      "version": "0.0.9"
     },
     "node_modules/@0xsequence/abi": {
       "version": "0.43.34",
@@ -2224,5 +2224,5 @@
       }
     }
   },
-  "version": "0.0.8"
+  "version": "0.0.9"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aori-io/sdk",
-      "version": "0.0.12",
+      "version": "0.0.13",
       "license": "MIT",
       "dependencies": {
         "@opensea/seaport-js": "^2.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aori-io/sdk",
-      "version": "0.0.11",
+      "version": "0.0.12",
       "license": "MIT",
       "dependencies": {
         "@opensea/seaport-js": "^2.0.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typed-emitter": "^2.1.0",
         "typescript": "^5.2.2"
       },
-      "version": "0.0.6"
+      "version": "0.0.7"
     },
     "node_modules/@0xsequence/abi": {
       "version": "0.43.34",
@@ -2224,5 +2224,5 @@
       }
     }
   },
-  "version": "0.0.6"
+  "version": "0.0.7"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "typed-emitter": "^2.1.0",
         "typescript": "^5.2.2"
       },
-      "version": "0.0.5"
+      "version": "0.0.6"
     },
     "node_modules/@0xsequence/abi": {
       "version": "0.43.34",
@@ -2224,5 +2224,5 @@
       }
     }
   },
-  "version": "0.0.5"
+  "version": "0.0.6"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@types/ws": "^8.5.5",
     "ts-node": "^10.9.1",
     "typechain": "^8.3.1",
-    "typed-emitter": "^2.1.0",
     "typescript": "^5.2.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "out/index.js",
   "types": "out/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aori-io/sdk",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "types": "typechain --target=ethers-v6 abi/*.json --out-dir src/types",
     "test": "",
     "build": "tsc",
-    "clean": "rm -rf out"
+    "clean": "rm -rf out",
+    "prepublish": "npm run build"
   },
   "dependencies": {
     "@opensea/seaport-js": "^2.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@aori-io/sdk",
   "version": "0.0.6",
+  "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "@aori-io/sdk",
   "version": "0.0.3",
-  "main": "out/index.js",
-  "types": "out/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "types": "typechain --target=ethers-v6 abi/*.json --out-dir src/types",
     "test": "",

--- a/src/bots/XYK.ts
+++ b/src/bots/XYK.ts
@@ -11,7 +11,7 @@ export class XYK extends LimitOrderManager {
     aToken: ERC20 = null as any;
     bToken: ERC20 = null as any;
     chainId: number = 5;
-    counter: number = 0;
+
     async initialise({ chainId, aTokenAddress, bTokenAddress }: { chainId: number, aTokenAddress: string, bTokenAddress: string }): Promise<void> {
         super.initialise();
 

--- a/src/bots/XYK.ts
+++ b/src/bots/XYK.ts
@@ -56,6 +56,7 @@ export class XYK extends LimitOrderManager {
         });
 
         // Make new orders
+        console.log("Making new orders...");
         const aBalance: bigint = await this.aToken.balanceOf(this.wallet.address);
         const bBalance: bigint = await this.bToken.balanceOf(this.wallet.address);
         const k = aBalance * bBalance;

--- a/src/providers/AoriProvider.ts
+++ b/src/providers/AoriProvider.ts
@@ -40,6 +40,9 @@ export abstract class AoriProvider extends (EventEmitter as new () => TypedEmitt
             }
 
             switch (this.messages[id]) {
+                case AoriMethods.Ping:
+                    console.log(`Received ${result} back`);
+                    break;
                 case AoriMethods.AuthWallet:
                     this.jwt = result.auth;
                     break;
@@ -100,6 +103,18 @@ export abstract class AoriProvider extends (EventEmitter as new () => TypedEmitt
     /*//////////////////////////////////////////////////////////////
                                 ACTIONS
     //////////////////////////////////////////////////////////////*/
+
+    async ping() {
+        const id = this.counter;
+        this.messages[id] = AoriMethods.Ping;
+        this.actionsWebsocket.send(JSON.stringify({
+            id,
+            jsonrpc: "2.0",
+            method: AoriMethods.Ping,
+            params: []
+        }));
+        this.counter++;
+    }
 
     async authWallet() {
         const { address } = this.wallet;

--- a/src/providers/AoriProvider.ts
+++ b/src/providers/AoriProvider.ts
@@ -39,7 +39,7 @@ export class AoriProvider extends TypedEventEmitter<AoriMethodsEvents> {
                 throw error;
             }
 
-            switch (this.messages[id]) {
+            switch (this.messages[id] || null) {
                 case AoriMethods.Ping:
                     console.log(`Received ${result} back`);
                     break;
@@ -48,6 +48,15 @@ export class AoriProvider extends TypedEventEmitter<AoriMethodsEvents> {
                     break;
                 case AoriMethods.ViewOrderbook:
                     this.emit(ResponseEvents.AoriMethods.ViewOrderbook, result.orders);
+                    break;
+                case AoriMethods.MakeOrder:
+                    this.emit(ResponseEvents.AoriMethods.MakeOrder, result.orderHash);
+                    break;
+                case AoriMethods.CancelOrder:
+                    this.emit(ResponseEvents.AoriMethods.CancelOrder, result.orderHash);
+                    break;
+                case AoriMethods.TakeOrder:
+                    this.emit(ResponseEvents.AoriMethods.TakeOrder, result.orderHash);
                     break;
                 case AoriMethods.AccountOrders:
                     this.emit(ResponseEvents.AoriMethods.AccountOrders, result.orders);
@@ -64,6 +73,7 @@ export class AoriProvider extends TypedEventEmitter<AoriMethodsEvents> {
                             this.emit(ResponseEvents.NotificationEvents.OrderToExecute, data);
                             break;
                         default:
+                            console.error(`Unexpected notification event: ${type}`);
                             break;
                     }
                     break;

--- a/src/providers/AoriProvider.ts
+++ b/src/providers/AoriProvider.ts
@@ -1,11 +1,22 @@
 import { JsonRpcProvider, Wallet, ZeroAddress } from "ethers";
-import TypedEmitter from "typed-emitter";
-import { EventEmitter, WebSocket } from "ws";
+import { WebSocket } from "ws";
 import { OrderWithCounter } from "../utils/helpers";
-import { ViewOrderbookQuery } from "./interfaces";
-import { AoriEvents, AoriMethods, NotificationEvents, ResponseEvents, SubscriptionEvents } from "./utils";
+import { TypedEventEmitter } from "../utils/TypedEventEmitter";
+import { OrderToExecute, OrderView, ViewOrderbookQuery } from "./interfaces";
+import { AoriMethods, NotificationEvents, ResponseEvents, SubscriptionEvents } from "./utils";
 
-export class AoriProvider extends (EventEmitter as new () => TypedEmitter<AoriEvents>) {
+type AoriMethodsEvents = {
+    [ResponseEvents.NotificationEvents.OrderToExecute]: [orderToExecute: OrderToExecute],
+    [ResponseEvents.AoriMethods.ViewOrderbook]: [orders: OrderView[]],
+    [ResponseEvents.AoriMethods.AccountOrders]: [orders: OrderView[]],
+    [ResponseEvents.AoriMethods.OrderStatus]: [order: OrderView],
+    [ResponseEvents.SubscriptionEvents.OrderCreated]: [order: OrderView],
+    [ResponseEvents.SubscriptionEvents.OrderCancelled]: [orderHash: string],
+    [ResponseEvents.SubscriptionEvents.OrderTaken]: [orderHash: string],
+    [ResponseEvents.SubscriptionEvents.OrderFulfilled]: [orderHash: string],
+};
+
+export class AoriProvider extends TypedEventEmitter<AoriMethodsEvents> {
     actionsWebsocket: WebSocket;
     subscriptionsWebsocket: WebSocket
     wallet: Wallet;

--- a/src/providers/AoriProvider.ts
+++ b/src/providers/AoriProvider.ts
@@ -110,7 +110,7 @@ export class AoriProvider extends TypedEventEmitter<AoriMethodsEvents> {
         outputAmount,
         chainId = 5
     }: {
-        offerer: string;
+        offerer?: string;
         inputToken: string;
         inputTokenType?: ItemType;
         inputAmount: BigNumberish;

--- a/src/providers/AoriProvider.ts
+++ b/src/providers/AoriProvider.ts
@@ -5,7 +5,7 @@ import { OrderWithCounter } from "../utils/helpers";
 import { ViewOrderbookQuery } from "./interfaces";
 import { AoriEvents, AoriMethods, NotificationEvents, ResponseEvents, SubscriptionEvents } from "./utils";
 
-export abstract class AoriProvider extends (EventEmitter as new () => TypedEmitter<AoriEvents>) {
+export class AoriProvider extends (EventEmitter as new () => TypedEmitter<AoriEvents>) {
     actionsWebsocket: WebSocket;
     subscriptionsWebsocket: WebSocket
     wallet: Wallet;

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -27,6 +27,9 @@ export const ResponseEvents = { AoriMethods, NotificationEvents, SubscriptionEve
 export type AoriMethodsEvents = {
     [ResponseEvents.NotificationEvents.OrderToExecute]: [orderToExecute: OrderToExecute],
     [ResponseEvents.AoriMethods.ViewOrderbook]: [orders: OrderView[]],
+    [ResponseEvents.AoriMethods.MakeOrder]: [orderHash: string],
+    [ResponseEvents.AoriMethods.CancelOrder]: [orderHash: string],
+    [ResponseEvents.AoriMethods.TakeOrder]: [orderHash: string],
     [ResponseEvents.AoriMethods.AccountOrders]: [orders: OrderView[]],
     [ResponseEvents.AoriMethods.OrderStatus]: [order: OrderView],
     [ResponseEvents.SubscriptionEvents.OrderCreated]: [order: OrderView],

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -24,13 +24,13 @@ export enum SubscriptionEvents {
 
 export const ResponseEvents = { AoriMethods, NotificationEvents, SubscriptionEvents };
 
-export type AoriEvents = {
-    [ResponseEvents.NotificationEvents.OrderToExecute]: (orderToExecute: OrderToExecute) => void,
-    [ResponseEvents.AoriMethods.ViewOrderbook]: (orders: OrderView[]) => void,
-    [ResponseEvents.AoriMethods.AccountOrders]: (orders: OrderView[]) => void,
-    [ResponseEvents.AoriMethods.OrderStatus]: (order: OrderView) => void,
-    [ResponseEvents.SubscriptionEvents.OrderCreated]: (order: OrderView) => void,
-    [ResponseEvents.SubscriptionEvents.OrderCancelled]: (orderHash: string) => void,
-    [ResponseEvents.SubscriptionEvents.OrderTaken]: (orderHash: string) => void,
-    [ResponseEvents.SubscriptionEvents.OrderFulfilled]: (orderHash: string) => void,
-}
+export type AoriMethodsEvents = {
+    [ResponseEvents.NotificationEvents.OrderToExecute]: [orderToExecute: OrderToExecute],
+    [ResponseEvents.AoriMethods.ViewOrderbook]: [orders: OrderView[]],
+    [ResponseEvents.AoriMethods.AccountOrders]: [orders: OrderView[]],
+    [ResponseEvents.AoriMethods.OrderStatus]: [order: OrderView],
+    [ResponseEvents.SubscriptionEvents.OrderCreated]: [order: OrderView],
+    [ResponseEvents.SubscriptionEvents.OrderCancelled]: [orderHash: string],
+    [ResponseEvents.SubscriptionEvents.OrderTaken]: [orderHash: string],
+    [ResponseEvents.SubscriptionEvents.OrderFulfilled]: [orderHash: string],
+};

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -1,6 +1,7 @@
 import { OrderToExecute, OrderView } from "./interfaces";
 
 export enum AoriMethods {
+    Ping = "aori_ping",
     AuthWallet = "aori_authWallet",
     ViewOrderbook = "aori_viewOrderbook",
     MakeOrder = "aori_makeOrder",

--- a/src/utils/TypedEventEmitter.ts
+++ b/src/utils/TypedEventEmitter.ts
@@ -1,0 +1,26 @@
+import { EventEmitter } from "events";
+
+export class TypedEventEmitter<TEvents extends Record<string, any>> {
+    private emitter = new EventEmitter()
+
+    emit<TEventName extends keyof TEvents & string>(
+        eventName: TEventName,
+        ...eventArg: TEvents[TEventName]
+    ) {
+        this.emitter.emit(eventName, ...(eventArg as []))
+    }
+
+    on<TEventName extends keyof TEvents & string>(
+        eventName: TEventName,
+        handler: (...eventArg: TEvents[TEventName]) => void
+    ) {
+        this.emitter.on(eventName, handler as any)
+    }
+
+    off<TEventName extends keyof TEvents & string>(
+        eventName: TEventName,
+        handler: (...eventArg: TEvents[TEventName]) => void
+    ) {
+        this.emitter.off(eventName, handler as any)
+    }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,7 +50,7 @@
     // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
     // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    "outDir": "./out", /* Specify an output folder for all emitted files. */
+    "outDir": "./dist", /* Specify an output folder for all emitted files. */
     // "removeComments": true,                           /* Disable emitting comments. */
     // "noEmit": true,                                   /* Disable emitting files from a compilation. */
     // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */


### PR DESCRIPTION
# Aori TypeScript SDK

This repository contains all the code required to locally install and run the Aori SDK. 
This repo was designed such that integrations for our partners can be as smooth and seamless as possible, providing all the necessary abstractions to allow anyone to easily start building on top of the Aori Protocol.
If you have any further questions, refer to [the technical documentation](https://www.aori.io/developers).
Alternatively, please reach out to us [on Discord](https://discord.gg/K37wkh2ZfR) or [on Twitter](https://twitter.com/aori_io).

Contained within this SDK are the following utilities:
- Types: All custom types used within the Protocol
- Provider: AoriProvider class allows for connection to the protocol and includes class extensions OrderbookListener and LimitOrderManager
- Dynamic Order Hashing: Utilizes EIP-712 standard for generating typed data hashes for orders + OrderHasher class for deriving unique order hashes

This SDK is released under the [MIT License](LICENSE).

# Installation

To install the SDK, run the following command:

```bash
npm install @aori-io/sdk
```

Or using Yarn:

```bash
yarn add @aori-io/sdk
```

# Initialization

After installation, use the following import command to interact with the SDK:

```typescript
import * as AoriSDK from '@aori-io/sdk';
```
Then access specific functions like so:
```typescript
const formattedLimitOrder = AoriSDK.formatIntoLimitOrder();
```